### PR TITLE
Remove redundant constraint

### DIFF
--- a/Sources/Enclosed.swift
+++ b/Sources/Enclosed.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Operadics
 
-extension BidirectionalCollection where Iterator.Element == Doc, IndexDistance == Int, SubSequence.Iterator.Element == Doc {
+extension BidirectionalCollection where Iterator.Element == Doc, IndexDistance == Int {
     
     /// Intersperses punctuation inside docs
     public func punctuate(with punctuation: Doc) -> [Doc] {


### PR DESCRIPTION
Fixes the following warning:

> Redundant same-type constraint 'Self.SubSequence.Iterator.Element' == 'Doc'